### PR TITLE
System Monitoring Script

### DIFF
--- a/Linux/CPT-LX-001/CPT-LX-001_nsavinda/README.md
+++ b/Linux/CPT-LX-001/CPT-LX-001_nsavinda/README.md
@@ -1,0 +1,30 @@
+# System Monitor 
+
+## Introduction
+This is a simple system monitor that logs the CPU, memory, and disk usage of a system to a file. 
+
+## Usage
+
+To run the system monitor, simply run the following command:
+
+```bash
+./system_monitor.sh
+```
+
+## Add to crontab
+
+To run the system monitor every 10 minutes, run the following command:
+
+```bash
+./system_monitor.sh enable
+```
+
+or
+
+Add the following line to your crontab:
+
+```bash
+*/10 * * * * /path/to/system_monitor.sh
+```
+
+

--- a/Linux/CPT-LX-001/CPT-LX-001_nsavinda/system_monitor.log
+++ b/Linux/CPT-LX-001/CPT-LX-001_nsavinda/system_monitor.log
@@ -1,0 +1,2 @@
+[2024-08-18T12:50:00+0530] | CPU: 7.3% | Memory: 6.6GB (42.9205%) | Disk: 95% of /dev/nvme0n1p1, 1% of /dev/nvme0n1p2
+[2024-08-18T13:00:00+0530] | CPU: 7.2% | Memory: 7.3GB (47.149%) | Disk: 95% of /dev/nvme0n1p1, 1% of /dev/nvme0n1p2

--- a/Linux/CPT-LX-001/CPT-LX-001_nsavinda/system_monitor.sh
+++ b/Linux/CPT-LX-001/CPT-LX-001_nsavinda/system_monitor.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Create a cron job
+if [ "$1" == "enable" ]; then
+    SCRIPT_PATH="$(realpath "$0")"
+    CRON_JOB="*/10 * * * * $SCRIPT_PATH"
+    (crontab -l ; echo "$CRON_JOB" ) | crontab -
+    exit 0
+fi
+
+
+LOG_FILE="$(dirname $0)/system_monitor.log"
+# LOG_FILE="/var/log/system_monitor.log"
+
+# Get CPU Percentage
+CPU_USAGE=$(top -bn1 | grep "Cpu(s):" | awk '{print $2 + $4"%" }' )
+
+
+# Get Memory Info
+MEM_INFO=$(free  | grep "Mem:" | awk '{print $3" "$2}' )
+MEM_USAGE=$(numfmt --to=iec --suffix=B --padding=2 $(awk '{print $1*1024}' <<< $MEM_INFO))
+# Memory Percentage
+MEM_USAGE_PER=$(awk '{print ($1/$2)*100}' <<< $MEM_INFO )
+
+# Get Disk Usage
+DISK_USAGE=$(df -h | grep '^/dev/' | awk '{printf (NR>1 ? ", " : "") "%s of %s", $5, $1}')
+
+# Get Current Timestamp
+TIMESTAMP=$(date "+[%Y-%m-%dT%H:%M:%S%z]")
+
+echo "$TIMESTAMP | CPU: $CPU_USAGE | Memory: $MEM_USAGE ($MEM_USAGE_PER%) | Disk: $DISK_USAGE" >>  $LOG_FILE


### PR DESCRIPTION
This pull request introduces a Bash script that logs CPU, memory, and disk usage on a system. 
Additionally, the script can add itself as a cron job for continuous monitoring.

Tested Environments:
- Arch Linux Desktop (Kernel 6.10.3)
- Alma Linux Cloud VM (Kernel 5.14.0)

Related Issue: Resolves #5