### PR TITLE
Feature/CPT-LX-001 Create bash script for system monitor

### DIFF
--- a/Linux/CPT-LX-001/CPT-LX-001_dsmabulage/README.md
+++ b/Linux/CPT-LX-001/CPT-LX-001_dsmabulage/README.md
@@ -1,0 +1,58 @@
+# System Monitoring Bash Script
+
+## Overview
+
+This repository contains a Bash script for monitoring system resources, including CPU usage, memory usage, and disk usage. The script logs the output to a file with a timestamp. You can also set up a cron job to run the script periodically.
+
+## Files
+
+- `system_monitor.sh`: The Bash script for system monitoring.
+- `system_monitor.log`: A sample log output after running the script.
+- `README.md`: This file with instructions on how to run the script and set up the cron job.
+
+## Prerequisites
+
+- Basic knowledge of Linux commands and Bash scripting.
+- A Linux environment (e.g., local machine, VM, or cloud instance).
+
+## Script Details
+
+### `system_monitor.sh`
+
+The script performs the following tasks:
+
+1. **Capture CPU Usage**: Uses `top` command to get the current CPU usage.
+2. **Capture Memory Usage**: Uses `free` command to get the current memory usage.
+3. **Capture Disk Usage**: Uses `df` command to get the current disk usage.
+4. **Log Output**: Writes the timestamp and system resource usage to `system_monitor.log`.
+
+## Script Execution
+
+### 1. Make the Script Executable
+
+Run the following command to give executable permissions to the script:
+
+```bash
+chmod +x system_monitor.sh
+```
+
+### 2. Run the Script
+
+Execute the script manually to verify that it logs the system information correctly:
+
+```bash
+./system_monitor.sh
+```
+
+### 3. Set Up a Cron Job
+
+To run the script every 10 minutes, add the following line to your crontab file:
+
+```bash
+*/10 * * * * /path/to/system_monitor.sh
+```
+Replace /path/to/ with the directory where your script is located. To edit your crontab file, use the command:
+
+```bash
+crontab -e
+```

--- a/Linux/CPT-LX-001/CPT-LX-001_dsmabulage/system_monitor.log
+++ b/Linux/CPT-LX-001/CPT-LX-001_dsmabulage/system_monitor.log
@@ -1,0 +1,20 @@
+Timestamp: 2024-08-24 03:06:03
+CPU Usage: 38.5%
+Memory Usage: 56.8663%
+Disk Usage: 9%
+---------------------------
+Timestamp: 2024-08-24 03:07:14
+CPU Usage: 6.5%
+Memory Usage: 57.3359%
+Disk Usage: 9%
+---------------------------
+Timestamp: 2024-08-24 03:08:44
+CPU Usage: 6.7%
+Memory Usage: 56.7178%
+Disk Usage: 9%
+---------------------------
+Timestamp: 2024-08-24 03:09:26
+CPU Usage: 17.6%
+Memory Usage: 57.024%
+Disk Usage: 9%
+---------------------------

--- a/Linux/CPT-LX-001/CPT-LX-001_dsmabulage/system_monitor.sh
+++ b/Linux/CPT-LX-001/CPT-LX-001_dsmabulage/system_monitor.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Define log file
+LOG_FILE="system_monitor.log"
+
+# Get the current timestamp
+timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+
+# Capture CPU usage
+cpu_usage=$(top -bn1 | grep "Cpu(s)" | sed "s/.*, *\([0-9.]*\)%* id.*/\1/" | awk '{print 100 - $1"%"}')
+
+# Capture memory usage
+memory_usage=$(free | grep Mem | awk '{print $3/$2 * 100.0"%"}')
+
+# Capture disk usage
+disk_usage=$(df / | grep / | awk '{print $5}')
+
+# Log the output to the log file
+echo "Timestamp: $timestamp" >> "$LOG_FILE"
+echo "CPU Usage: $cpu_usage" >> "$LOG_FILE"
+echo "Memory Usage: $memory_usage" >> "$LOG_FILE"
+echo "Disk Usage: $disk_usage" >> "$LOG_FILE"
+echo "---------------------------" >> "$LOG_FILE"


### PR DESCRIPTION
Adds a Bash script for monitoring system resources, including CPU, memory, and disk usage. The script logs this data to `system_monitor.log` with a timestamp. Setup instructions for running the script manually and optionally scheduling it with a cron job are included.

Files added:
- `system_monitor.sh` - Bash script for system monitoring.
- `system_monitor.log` - Sample log output.
- `README.md` - Instructions for setup and usage.
